### PR TITLE
FIX: Pin Eve stack for Python 3.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,6 +15,12 @@ $ curl -i -H "Content-Type: application/json" http://localhost/api/v1/T1w
 
 Swagger API documentation available at `http://localhost/docs`.
 
+## Compatibility note (Python 3.7 base image)
+The `dockereve-master/eve-app` image uses a Python 3.7 base. To avoid
+`functools.cache` import errors from newer Flask/Werkzeug releases, the
+`eve-app/requirements.txt` pins Eve to `1.1.5` and caps Flask/Werkzeug below
+2.1. If you upgrade the runtime Python, revisit these pins accordingly.
+
 ## Environment variables in Docker
 To properly run the file dockereve-master/.env needs to be populated the following are the default values:
 ```

--- a/dockereve-master/eve-app/requirements.txt
+++ b/dockereve-master/eve-app/requirements.txt
@@ -1,3 +1,5 @@
 gunicorn
-eve
+eve==1.1.5
+flask<2.1
+werkzeug<2.1
 eve-swagger>=0.1


### PR DESCRIPTION
### Motivation
- The endpoints image uses a Python 3.7 base and newer Flask/Werkzeug releases can import `functools.cache`, which causes runtime import errors; pinning avoids that while preserving the existing base image.

### Description
- Updated `dockereve-master/eve-app/requirements.txt` to pin `eve==1.1.5` and cap `flask`/`werkzeug` below `2.1`, and added a README compatibility note documenting the rationale.

### Testing
- Ran `python -m pip index versions eve` and `python -m pip download eve==1.1.5` (succeeded), ran `pipx run ruff format --diff .` (reported formatting diffs), ran `pipx run ruff check .` (failed with a duplicate `run_id` key in `settings.py` and a bare `except` in `tools/json2csv.py`), and attempted `docker-compose build` which could not run in this environment because `docker-compose`/`docker` are not available.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978ae8e67c483308c3ede28c7b4c69c)