### PR TITLE
CHORE: Update Eve app base image and dependency pins

### DIFF
--- a/dockereve-master/eve-app/Dockerfile
+++ b/dockereve-master/eve-app/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.11-slim
 
 WORKDIR /usr/src/app
 
@@ -6,4 +6,3 @@ ADD . /usr/src/app
 
 RUN pip3 install -r requirements.txt
 RUN pip3 install pytest
-RUN sed -i 's/\[scheme\]/\["https"\]/' /usr/local/lib/python3.7/site-packages/eve_swagger/objects.py

--- a/dockereve-master/eve-app/requirements.txt
+++ b/dockereve-master/eve-app/requirements.txt
@@ -1,5 +1,5 @@
 gunicorn
-eve==1.1.5
-flask<2.1
-werkzeug<2.1
-eve-swagger>=0.1
+eve==2.2.4
+flask>=2.2,<3
+werkzeug>=2.2,<3
+eve-swagger==0.2.0


### PR DESCRIPTION
### Motivation

- Move the Eve API container to a supported Python runtime and remove an ad-hoc runtime patch that modified installed package source at build time.

### Description

- Bump the Eve app Docker base image from `python:3.7-slim` to `python:3.11-slim` and remove the `sed` workaround from the Dockerfile.
- Update dependency pins in `dockereve-master/eve-app/requirements.txt` to `eve==2.2.4`, `flask>=2.2,<3`, `werkzeug>=2.2,<3`, and `eve-swagger==0.2.0` so the swagger code no longer requires an in-Docker source edit.

### Testing

- Ran `pipx run ruff format --diff .` which reported files that would be reformatted (did not auto-apply) indicating style diffs.
- Ran `pipx run ruff check .` which reported issues unrelated to these two files (a repeated dict key in `settings.py` and a bare `except` in `tools/json2csv.py`); the lint check therefore reported failures that should be addressed in a follow-up cleanup PR.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978c229b3988330b1ec485d0b6983e0)