### PR TITLE
CHORE: Add scheduled healthcheck workflow

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,9 +1,9 @@
 name: Healthcheck
 
-on:
+"on":
   schedule:
     - cron: "*/15 * * * *"
-  workflow_dispatch:
+  workflow_dispatch: {}
 
 permissions:
   contents: write

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -71,12 +71,12 @@ jobs:
           cp health_out/index.html health/index.html
           cp health_out/status.json health/status.json
 
-          if git diff --quiet; then
+          git add health/index.html health/status.json
+          if git diff --cached --quiet; then
             echo "No changes to publish."
             exit 0
           fi
 
-          git add health/index.html health/status.json
           git config user.name "github-actions"
           git config user.email "github-actions@users.noreply.github.com"
           git commit -m "chore(healthcheck): update status page"

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -1,0 +1,186 @@
+name: Healthcheck
+
+on:
+  schedule:
+    - cron: "*/15 * * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  probe:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Probe endpoints
+        env:
+          API_TOKEN: ${{ secrets.API_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+          auth_header=()
+          if [ -n "${API_TOKEN:-}" ]; then
+            auth_header=( -H "Authorization: Bearer ${API_TOKEN}" )
+          fi
+
+          probe() {
+            local name=$1
+            local url=$2
+            local result
+            result=$(curl -sS -o /dev/null -w "%{http_code} %{time_total}" "${auth_header[@]}" "$url" || true)
+            local code time
+            code=$(awk '{print $1}' <<<"$result")
+            time=$(awk '{print $2}' <<<"$result")
+            if [ -z "$code" ]; then
+              code="000"
+              time="0"
+            fi
+            printf '%s|%s|%s\n' "$name" "$code" "$time"
+          }
+
+          mkdir -p health_out
+          {
+            probe "swagger" "https://mriqc.nimh.nih.gov/"
+            probe "t1w" "https://mriqc.nimh.nih.gov/api/v1/T1w"
+            probe "bold" "https://mriqc.nimh.nih.gov/api/v1/bold"
+          } > health_out/raw.txt
+
+          python - <<'PY'
+import json
+from datetime import datetime, timezone
+
+status = "OK"
+endpoints = []
+
+with open("health_out/raw.txt") as handle:
+    for line in handle:
+        name, code, duration = line.strip().split("|")
+        code_int = int(code) if code.isdigit() else 0
+        endpoints.append(
+            {
+                "name": name,
+                "url": {
+                    "swagger": "https://mriqc.nimh.nih.gov/",
+                    "t1w": "https://mriqc.nimh.nih.gov/api/v1/T1w",
+                    "bold": "https://mriqc.nimh.nih.gov/api/v1/bold",
+                }[name],
+                "status_code": code_int,
+                "duration_seconds": float(duration),
+                "ok": 200 <= code_int < 400,
+            }
+        )
+        if not (200 <= code_int < 400):
+            status = "WARN"
+
+payload = {
+    "status": status,
+    "since": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+    "endpoints": endpoints,
+}
+
+with open("health_out/status.json", "w", encoding="utf-8") as handle:
+    json.dump(payload, handle, indent=2, sort_keys=True)
+PY
+
+          python - <<'PY'
+import json
+from datetime import datetime, timezone
+
+with open("health_out/status.json", encoding="utf-8") as handle:
+    payload = json.load(handle)
+
+now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+status = payload["status"]
+
+rows = "\n".join(
+    """<tr>
+        <td>{name}</td>
+        <td><a href=\"{url}\">{url}</a></td>
+        <td>{code}</td>
+        <td>{duration:.3f}s</td>
+        <td>{ok}</td>
+      </tr>""".format(
+        name=item["name"],
+        url=item["url"],
+        code=item["status_code"],
+        duration=item["duration_seconds"],
+        ok="OK" if item["ok"] else "WARN",
+    )
+    for item in payload["endpoints"]
+)
+
+html = f"""<!doctype html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"utf-8\" />
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+    <title>MRIQC Healthcheck</title>
+    <style>
+      body {{ font-family: sans-serif; margin: 2rem; }}
+      .status {{ font-weight: bold; }}
+      table {{ border-collapse: collapse; width: 100%; margin-top: 1rem; }}
+      th, td {{ border: 1px solid #ddd; padding: 0.5rem; text-align: left; }}
+      th {{ background: #f5f5f5; }}
+    </style>
+  </head>
+  <body>
+    <h1>MRIQC API Health</h1>
+    <p class=\"status\">Overall status: {status}</p>
+    <p>Since: {payload['since']}</p>
+    <p>Updated: {now}</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Endpoint</th>
+          <th>URL</th>
+          <th>Status Code</th>
+          <th>Duration</th>
+          <th>Result</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows}
+      </tbody>
+    </table>
+  </body>
+</html>
+"""
+
+with open("health_out/index.html", "w", encoding="utf-8") as handle:
+    handle.write(html)
+PY
+
+      - name: Publish to gh-pages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          set -euo pipefail
+
+          git fetch origin gh-pages || true
+          if git show-ref --quiet refs/remotes/origin/gh-pages; then
+            git checkout gh-pages
+          else
+            git checkout --orphan gh-pages
+            git rm -rf .
+          fi
+
+          mkdir -p health
+          cp health_out/index.html health/index.html
+          cp health_out/status.json health/status.json
+
+          if git diff --quiet; then
+            echo "No changes to publish."
+            exit 0
+          fi
+
+          git add health/index.html health/status.json
+          git config user.name "github-actions"
+          git config user.email "github-actions@users.noreply.github.com"
+          git commit -m "chore(healthcheck): update status page"
+          git push origin gh-pages

--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -23,7 +23,6 @@ jobs:
         run: |
           set -euo pipefail
 
-          timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
           auth_header=()
           if [ -n "${API_TOKEN:-}" ]; then
             auth_header=( -H "Authorization: Bearer ${API_TOKEN}" )
@@ -51,110 +50,8 @@ jobs:
             probe "bold" "https://mriqc.nimh.nih.gov/api/v1/bold"
           } > health_out/raw.txt
 
-          python - <<'PY'
-import json
-from datetime import datetime, timezone
-
-status = "OK"
-endpoints = []
-
-with open("health_out/raw.txt") as handle:
-    for line in handle:
-        name, code, duration = line.strip().split("|")
-        code_int = int(code) if code.isdigit() else 0
-        endpoints.append(
-            {
-                "name": name,
-                "url": {
-                    "swagger": "https://mriqc.nimh.nih.gov/",
-                    "t1w": "https://mriqc.nimh.nih.gov/api/v1/T1w",
-                    "bold": "https://mriqc.nimh.nih.gov/api/v1/bold",
-                }[name],
-                "status_code": code_int,
-                "duration_seconds": float(duration),
-                "ok": 200 <= code_int < 400,
-            }
-        )
-        if not (200 <= code_int < 400):
-            status = "WARN"
-
-payload = {
-    "status": status,
-    "since": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
-    "endpoints": endpoints,
-}
-
-with open("health_out/status.json", "w", encoding="utf-8") as handle:
-    json.dump(payload, handle, indent=2, sort_keys=True)
-PY
-
-          python - <<'PY'
-import json
-from datetime import datetime, timezone
-
-with open("health_out/status.json", encoding="utf-8") as handle:
-    payload = json.load(handle)
-
-now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
-status = payload["status"]
-
-rows = "\n".join(
-    """<tr>
-        <td>{name}</td>
-        <td><a href=\"{url}\">{url}</a></td>
-        <td>{code}</td>
-        <td>{duration:.3f}s</td>
-        <td>{ok}</td>
-      </tr>""".format(
-        name=item["name"],
-        url=item["url"],
-        code=item["status_code"],
-        duration=item["duration_seconds"],
-        ok="OK" if item["ok"] else "WARN",
-    )
-    for item in payload["endpoints"]
-)
-
-html = f"""<!doctype html>
-<html lang=\"en\">
-  <head>
-    <meta charset=\"utf-8\" />
-    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
-    <title>MRIQC Healthcheck</title>
-    <style>
-      body {{ font-family: sans-serif; margin: 2rem; }}
-      .status {{ font-weight: bold; }}
-      table {{ border-collapse: collapse; width: 100%; margin-top: 1rem; }}
-      th, td {{ border: 1px solid #ddd; padding: 0.5rem; text-align: left; }}
-      th {{ background: #f5f5f5; }}
-    </style>
-  </head>
-  <body>
-    <h1>MRIQC API Health</h1>
-    <p class=\"status\">Overall status: {status}</p>
-    <p>Since: {payload['since']}</p>
-    <p>Updated: {now}</p>
-    <table>
-      <thead>
-        <tr>
-          <th>Endpoint</th>
-          <th>URL</th>
-          <th>Status Code</th>
-          <th>Duration</th>
-          <th>Result</th>
-        </tr>
-      </thead>
-      <tbody>
-        {rows}
-      </tbody>
-    </table>
-  </body>
-</html>
-"""
-
-with open("health_out/index.html", "w", encoding="utf-8") as handle:
-    handle.write(html)
-PY
+          python test/healthcheck_status.py health_out/raw.txt health_out/status.json
+          python test/healthcheck_render.py health_out/status.json health_out/index.html
 
       - name: Publish to gh-pages
         env:

--- a/README.md
+++ b/README.md
@@ -15,6 +15,8 @@ $ curl -i -H "Content-Type: application/json" http://localhost/api/v1/T1w
 
 Swagger API documentation available at `http://localhost/docs`.
 
+Healthcheck page (GitHub Pages): `https://nipreps.github.io/mriqcwebapi/health/`.
+
 ## Tests
 ### Integration (pytest)
 These tests require a running Docker Compose stack and a valid API token.

--- a/test/healthcheck_render.py
+++ b/test/healthcheck_render.py
@@ -13,7 +13,7 @@ def main(status_path: str, output_path: str) -> None:
     rows = "\n".join(
         """<tr>
         <td>{name}</td>
-        <td><a href=\"{url}\">{url}</a></td>
+        <td><a href="{url}">{url}</a></td>
         <td>{code}</td>
         <td>{duration:.3f}s</td>
         <td>{ok}</td>
@@ -28,10 +28,10 @@ def main(status_path: str, output_path: str) -> None:
     )
 
     html = f"""<!doctype html>
-<html lang=\"en\">
+<html lang="en">
   <head>
-    <meta charset=\"utf-8\" />
-    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>MRIQC Healthcheck</title>
     <style>
       body {{ font-family: sans-serif; margin: 2rem; }}
@@ -43,7 +43,7 @@ def main(status_path: str, output_path: str) -> None:
   </head>
   <body>
     <h1>MRIQC API Health</h1>
-    <p class=\"status\">Overall status: {status}</p>
+    <p class="status">Overall status: {status}</p>
     <p>Since: {payload["since"]}</p>
     <p>Updated: {now}</p>
     <table>

--- a/test/healthcheck_render.py
+++ b/test/healthcheck_render.py
@@ -1,0 +1,72 @@
+import json
+import sys
+from datetime import datetime, timezone
+
+
+def main(status_path: str, output_path: str) -> None:
+    with open(status_path, encoding="utf-8") as handle:
+        payload = json.load(handle)
+
+    now = datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+    status = payload["status"]
+
+    rows = "\n".join(
+        """<tr>
+        <td>{name}</td>
+        <td><a href=\"{url}\">{url}</a></td>
+        <td>{code}</td>
+        <td>{duration:.3f}s</td>
+        <td>{ok}</td>
+      </tr>""".format(
+            name=item["name"],
+            url=item["url"],
+            code=item["status_code"],
+            duration=item["duration_seconds"],
+            ok="OK" if item["ok"] else "WARN",
+        )
+        for item in payload["endpoints"]
+    )
+
+    html = f"""<!doctype html>
+<html lang=\"en\">
+  <head>
+    <meta charset=\"utf-8\" />
+    <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\" />
+    <title>MRIQC Healthcheck</title>
+    <style>
+      body {{ font-family: sans-serif; margin: 2rem; }}
+      .status {{ font-weight: bold; }}
+      table {{ border-collapse: collapse; width: 100%; margin-top: 1rem; }}
+      th, td {{ border: 1px solid #ddd; padding: 0.5rem; text-align: left; }}
+      th {{ background: #f5f5f5; }}
+    </style>
+  </head>
+  <body>
+    <h1>MRIQC API Health</h1>
+    <p class=\"status\">Overall status: {status}</p>
+    <p>Since: {payload["since"]}</p>
+    <p>Updated: {now}</p>
+    <table>
+      <thead>
+        <tr>
+          <th>Endpoint</th>
+          <th>URL</th>
+          <th>Status Code</th>
+          <th>Duration</th>
+          <th>Result</th>
+        </tr>
+      </thead>
+      <tbody>
+        {rows}
+      </tbody>
+    </table>
+  </body>
+</html>
+"""
+
+    with open(output_path, "w", encoding="utf-8") as handle:
+        handle.write(html)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])

--- a/test/healthcheck_status.py
+++ b/test/healthcheck_status.py
@@ -1,0 +1,43 @@
+import json
+import sys
+from datetime import datetime, timezone
+
+URLS = {
+    "swagger": "https://mriqc.nimh.nih.gov/",
+    "t1w": "https://mriqc.nimh.nih.gov/api/v1/T1w",
+    "bold": "https://mriqc.nimh.nih.gov/api/v1/bold",
+}
+
+
+def main(raw_path: str, output_path: str) -> None:
+    status = "OK"
+    endpoints = []
+
+    with open(raw_path, encoding="utf-8") as handle:
+        for line in handle:
+            name, code, duration = line.strip().split("|")
+            code_int = int(code) if code.isdigit() else 0
+            endpoints.append(
+                {
+                    "name": name,
+                    "url": URLS[name],
+                    "status_code": code_int,
+                    "duration_seconds": float(duration),
+                    "ok": 200 <= code_int < 400,
+                }
+            )
+            if not (200 <= code_int < 400):
+                status = "WARN"
+
+    payload = {
+        "status": status,
+        "since": datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ"),
+        "endpoints": endpoints,
+    }
+
+    with open(output_path, "w", encoding="utf-8") as handle:
+        json.dump(payload, handle, indent=2, sort_keys=True)
+
+
+if __name__ == "__main__":
+    main(sys.argv[1], sys.argv[2])


### PR DESCRIPTION
### Motivation
- Provide an automated, lightweight probe of production MRIQC endpoints so uptime and basic responsiveness can be monitored without manual checks.
- Surface a simple static status page via GitHub Pages so operators can quickly validate service health and response codes.
- Keep changes minimal and non-invasive by implementing monitoring as a CI workflow rather than modifying runtime code or API behaviour.

### Description
- Add a GitHub Actions workflow at `.github/workflows/healthcheck.yml` that runs every 15 minutes (and on demand) to probe `https://mriqc.nimh.nih.gov/`, `.../api/v1/T1w`, and `.../api/v1/bold`, then renders `health/status.json` and `health/index.html` and publishes them to the `gh-pages` branch only when content changes.
- Document the published healthcheck page URL in `README.md` as `https://nipreps.github.io/mriqcwebapi/health/`.
- The workflow supports an optional `API_TOKEN` (from `secrets.API_TOKEN`) via an `Authorization: Bearer` header for endpoints that require auth.
- The workflow is designed to be low-risk and non-destructive because it only writes static artifacts to `gh-pages` when differences are detected.

### Testing
- Ran formatting check with `pipx run ruff format --diff .` and it reported the repo files are already formatted (succeeded).
- No unit or integration tests were added because this is a workflow-only change and the workflow itself has not been executed in CI as part of this PR.

---
References: #58.

[Codex Task](https://chatgpt.com/codex/tasks/task_e_69799ecd9418833086fc2b74dd6fd9ce)