### PR TITLE
FIX: Correct gh api issue query for downtime tracking

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -112,7 +112,7 @@ jobs:
         run: |
           set -euo pipefail
 
-          issues_json=$(gh api "repos/${GITHUB_REPOSITORY}/issues" -f state=open -f labels=downtime -f per_page=100)
+          issues_json=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/issues" -f state=open -f labels=downtime -f per_page=100)
           count=$(jq 'length' <<<"$issues_json")
           first_number=$(jq '.[0].number // empty' <<<"$issues_json")
           numbers=$(jq -r '.[].number' <<<"$issues_json" | paste -sd, -)


### PR DESCRIPTION
### Motivation
- The healthcheck workflow failed in the "Find downtime issues" step because `gh api` interpreted the labels payload incorrectly and returned HTTP 422, preventing the workflow from reliably retrieving/creating/closing downtime issues.

### Description
- Use an explicit GET for the issues query by adding `-X GET` to the `gh api` call in `.github/workflows/healthcheck.yml` so label filtering is parsed correctly.

### Testing
- Ran `pipx run ruff format --diff .` and `pipx run ruff check .`, and both commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979dfd9a6a4833086898a182661877d)