### PR TITLE
FIX: Scope healthcheck downtime issues by title tag

### DIFF
--- a/.github/workflows/healthcheck.yml
+++ b/.github/workflows/healthcheck.yml
@@ -126,10 +126,10 @@ jobs:
         run: |
           set -euo pipefail
 
-          issues_json=$(gh api -X GET "repos/${GITHUB_REPOSITORY}/issues" -f state=open -f labels=downtime -f per_page=100)
-          count=$(jq 'length' <<<"$issues_json")
-          first_number=$(jq '.[0].number // empty' <<<"$issues_json")
-          numbers=$(jq -r '.[].number' <<<"$issues_json" | paste -sd, -)
+          issues_json=$(gh api -X GET "search/issues" -f q="repo:${GITHUB_REPOSITORY} is:issue is:open label:downtime in:title [HEALTHCHECK]" -f per_page=100)
+          count=$(jq '.total_count // 0' <<<"$issues_json")
+          first_number=$(jq '.items[0].number // empty' <<<"$issues_json")
+          numbers=$(jq -r '.items[].number' <<<"$issues_json" | paste -sd, -)
 
           echo "count=${count}" >> "$GITHUB_OUTPUT"
           echo "first_number=${first_number}" >> "$GITHUB_OUTPUT"
@@ -143,7 +143,7 @@ jobs:
           set -euo pipefail
 
           gh api "repos/${GITHUB_REPOSITORY}/issues" \
-            -f title="Downtime detected: health checks failing" \
+            -f title="[HEALTHCHECK] Downtime detected: health checks failing" \
             -f body="@nipreps/webapi\n\nHealth check failing: https://www.nipreps.org/mriqcwebapi/health/" \
             -f labels='downtime'
 


### PR DESCRIPTION
### Motivation
- The scheduled healthcheck workflow was matching any issue labeled `downtime`, causing collisions with manually labeled issues, so automation should only consider issues explicitly created by the healthcheck runner.

### Description
- Update `.github/workflows/healthcheck.yml` to call the GitHub Search API with the query `repo:${GITHUB_REPOSITORY} is:issue is:open label:downtime in:title [HEALTHCHECK]`, adjust JSON parsing to read `.total_count` and `.items[][].number`, and prefix newly opened downtime issues with `[HEALTHCHECK]` in the title.

### Testing
- Ran the formatting check `pipx run ruff format --diff .`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6979ebe03124833085a4dc41752a49aa)